### PR TITLE
Add endpoint for venus e 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ This program works excellently together with Tomquist's great tools such as [b25
 MarstACK has been tested with:
 * my battery - Marstek Saturn-C B2500-H Firmware v110
 * [bbmfarp](https://github.com/bbmfarp) - Marstek Venus E (2. Gen) Firmware 152
+* Marstek Venus E (3. Gen) Firmware 147
+
+Note: for Marstek Venus E (3. Gen) to consider being connected to cloud it is additionally necessary
+to have a local mqtt broker running. See the [MarstACK Wiki](https://github.com/fignew/MarstACK/wiki)
+for more details.
 
 Please let me know if you have success with other models or if there are any errors that show up in the logs.
 I would recommend not doing any blind firmware updates as breakage is likely.

--- a/app/main.py
+++ b/app/main.py
@@ -74,6 +74,21 @@ async def set_b2500_report(request: Request):
     return JSONResponse(content={"code": 1, "msg": "ok"})
 
 
+@app.get("/prod/api/v1/setVenusDReporting")
+async def set_venus_d_reporting(request: Request):
+    """
+    Endpoint to emulate /prod/api/v1/setVenusDReporting. Despite the name this endpoint is used by
+    venus e 3.0.
+
+    Returns a simple JSON response {"code":1,"msg":"ok"}
+    """
+    # Log all query parameters
+    params = dict(request.query_params)
+    logger.debug(f"GET /prod/api/v1/setVenusDReporting - Query params: {params}")
+
+    return JSONResponse(content={"code": 1, "msg": "ok"})
+
+
 @app.get("/app/neng/getDateInfoeu.php", response_class=PlainTextResponse)
 async def get_date_info(request: Request):
     """


### PR DESCRIPTION
I've added support for my venus e 3.0. I've also added a note about the necessary additional mqtt broker. I would add this to the wiki if this MR gets merged. Also I want to point out that its possible to decrypt the traffic to the api endpoints. So Instead of just logging the request the decrypted payload could be logged or stored somewhere. Instructions can be found here: https://github.com/lucavb/prometheus-marstek-mqtt-exporter/blob/main/docs/network.md and the encryption is the same for b2500 and venus e 3.0 ;)